### PR TITLE
Fix problem where 'npm install' fails on Windows

### DIFF
--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -36,6 +36,7 @@ var editor = require('../service/swagger_editor');
 var cp = require('child_process');
 var swaggerSpec = require('swagger-tools').specs.v2_0;
 var netutil = require('../../util/net');
+var os = require('os');
 
 module.exports = {
   create: create,
@@ -294,10 +295,17 @@ function customizeClonedFiles(name, destDir, cb) {
 }
 
 function spawn(command, options, cwd, cb) {
+  var isWin = /^win/.test(os.platform());
 
   emit('Running \'%s %s\'...', command, options.join(' '));
 
-  var npm = cp.spawn(command, options, { cwd: cwd });
+  var npm = cp.spawn(isWin ?
+                       process.env.comspec :
+                       command,
+                     isWin ?
+                       ['/c'].concat(command, options) :
+                       options,
+                     { cwd: cwd });
   npm.stdout.on('data', function (data) {
     emit(data);
   });


### PR DESCRIPTION
Updated project.spawn to run `npm install` in a way that works on Windows.
