### PR TITLE
Fix 'npm install' on Windows (missing deps)

### DIFF
--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -240,7 +240,7 @@ function findProjectFile(startDir, options, cb) {
   var maxDepth = 50;
   while (current !== parent && maxDepth-- > 0) {
     current = parent;
-    var projectFile = path.resolve(current, 'package.json')
+    var projectFile = path.resolve(current, 'package.json');
     if (fs.existsSync(projectFile)) {
       return cb(null, projectFile);
     }
@@ -250,16 +250,16 @@ function findProjectFile(startDir, options, cb) {
 }
 
 function cloneSkeleton(name, destDir, cb) {
-
   var sourceDir = config.project.skeletonDir;
-  var nodeModulesPath = path.resolve(config.project.skeletonDir, 'node_modules');
+  var nodeModulesPath = path.resolve(sourceDir, 'node_modules');
 
-  var filter = function(name) {
-    if (name.indexOf(nodeModulesPath) >= 0) {
+  var filter = function(fileName) {
+    fileName = fileName.substr(sourceDir.length + 1);
+
+    if (fileName.indexOf('node_modules') === 0) {
       return false;
     }
-    var name = name.substr(config.project.skeletonDir.length + 1);
-    if (name.length > 0) { emit('creating: ' + name); }
+    if (fileName.length > 0) { emit('creating: ' + fileName); }
     return true;
   };
 
@@ -269,7 +269,7 @@ function cloneSkeleton(name, destDir, cb) {
   };
 
   ncp(sourceDir, destDir, options, function (err) {
-    if (err) { return cb(error); }
+    if (err) { return cb(err); }
     customizeClonedFiles(name, destDir, cb);
   });
 }
@@ -277,7 +277,7 @@ function cloneSkeleton(name, destDir, cb) {
 function customizeClonedFiles(name, destDir, cb) {
   var fileName = path.resolve(destDir, 'package.json');
   fs.readFile(fileName, { encoding: 'utf8' }, function(err, string) {
-    if (err) { return cb(error); }
+    if (err) { return cb(err); }
     var project = JSON.parse(string);
     delete(project.readme);
     delete(project.readmeFilename);


### PR DESCRIPTION
The filter used to filter out the node_modules from the project skeleton
was not matching anything because ncp mixes path separators on Windows.
