### PR TITLE
Add --silent flag to `a127 project edit`

### DIFF
--- a/bin/a127-project
+++ b/bin/a127-project
@@ -54,6 +54,7 @@ app
 app
   .command('edit [directory]')
   .description('Open swagger editor')
+  .option('-s --silent', 'do not open the browser')
   .action(execute(project.edit));
 
 app

--- a/lib/commands/service/swagger_editor.js
+++ b/lib/commands/service/swagger_editor.js
@@ -70,10 +70,18 @@ function edit(project, options, cb) {
   server.listen(0, 'localhost', function() {
     var port = server.address().port;
     var editorUrl = util.format('http://localhost:%d/#/edit', port);
+    var editApiUrl = util.format('http://localhost:%d/editor/spec', port);
+    var dontKillMessage = 'Do not terminate this process or close this window until finished editing.';
     emit('Starting Swagger editor.');
-    browser.open(editorUrl, function(err) {
-      if (err) { return cb(err); }
-      emit('Do not terminate this process or close this window until finished editing.');
-    });
+
+    if (!options.silent) {
+      browser.open(editorUrl, function(err) {
+        if (err) { return cb(err); }
+        emit(dontKillMessage);
+      });
+    } else {
+      emit('Running edit API server. You can make GET and PUT calls to ' + editApiUrl);
+      emit(dontKillMessage)
+    }
   });
 }

--- a/test/commands/project/project.js
+++ b/test/commands/project/project.js
@@ -410,6 +410,14 @@ describe('project', function() {
       });
     });
 
+     it('edit should exec editor with --silent flag', function(done) {
+      project.edit(projPath, {silent: true}, function(err) {
+        should.not.exist(err);
+        should(didEdit).true;
+        done();
+      });
+    });
+
     it('open should exec browser', function(done) {
       project.open(projPath, {}, function(err) {
         should.not.exist(err);


### PR DESCRIPTION
With --silent flag passed, `a127 project edit` will not open the
browser. This is helpful for end-to-end testing in non-GUI environments.
It also can be helpful for hooking other types of editors to a127