### PR TITLE
Update Swagger Editor to 2.9.1

### DIFF
--- a/config/swagger-editor.config.json
+++ b/config/swagger-editor.config.json
@@ -1,4 +1,9 @@
 {
+  "analytics": {
+    "google": {
+      "id": null
+    }
+  },
   "disableCodeGen": true,
   "disableNewUserIntro": true,
   "examplesFolder": "/spec-files/",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "request": "^2.47.0",
     "serve-static": "1.7.x",
     "superagent": "^0.21.0",
-    "swagger-editor": "2.8.1",
+    "swagger-editor": "2.9.1",
     "swagger-tools": "^0.7.0",
     "tail": "0.3.x",
     "unzip": "0.1.x",


### PR DESCRIPTION
This is updating Swagger Editor and also puts a placeholder for analytics id. Per Marsh, the analytics should be opt-in. A127 cli tools should ask user if they want to opt in and then it should put the GA ID in config. Please ask Marsh about more details on that.