### PR TITLE
Update apigee.js

### DIFF
--- a/lib/commands/account/providers/apigee.js
+++ b/lib/commands/account/providers/apigee.js
@@ -203,7 +203,8 @@ function removeVendorExtensions(key) {
 
 function buildApigeeResourceDefEndPoint(account, results) {
   //https://api.enterprise.apigee.com/v1/o/demo_bvt/apis/hello1/revisions/1/proxies/default/flows
-  return 'https://api.enterprise.apigee.com/v1/o/' +
+  // 20150317 replaced fixed url : return 'https://api.enterprise.apigee.com/v1/o/' +
+  return account.baseuri + '/v1/o/' +
     account.organization + '/apis/' +
     results.name + '/revisions/' +
     results.revision + '/proxies/default/flows';


### PR DESCRIPTION
Fixed buildApigeeResourceDefEndPoint to use the baseuri from the current account instead of static apigee-cloud url.