### PR TITLE
Fix `project start` swallowing app stdout/stderr

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "jszip": "2.4.x",
     "lodash": "2.4.x",
     "mocha": "2.1.x",
-    "nodemon": "1.2.x",
+    "nodemon": "^1.8.1",
     "request": "^2.47.0",
     "serve-static": "1.7.x",
     "superagent": "^0.21.0",


### PR DESCRIPTION
New version of nodemon does not exhibit the problem (using Node v5)