### PR TITLE
Allow changing project editor port via environment variable

### DIFF
--- a/lib/commands/service/swagger_editor.js
+++ b/lib/commands/service/swagger_editor.js
@@ -88,7 +88,8 @@ function edit(project, options, cb) {
 
   var http = require('http');
   var server = http.createServer(app);
-  server.listen(0, 'localhost', function() {
+  var port = process.env.PORT || 0;
+  server.listen(port, 'localhost', function() {
     var port = server.address().port;
     var editorUrl = util.format('http://localhost:%d/#/edit', port);
     var editApiUrl = util.format('http://localhost:%d/editor/spec', port);


### PR DESCRIPTION
This PR lets the user define a custom port via an environment variable. Fixes #37  