### PR TITLE
change to use config seeting for swagger file

### DIFF
--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -473,7 +473,7 @@ function readProject(directory, options, cb) {
     if (!project.api.main && project.script) { project.api.main = project.script.start; }
     if (!project.api.basePath) { project.api.basePath = qs.escape(project.name); }
     if (!project.api.swagger) {
-      var file = path.resolve(project.dirname, 'api', 'swagger', 'swagger.yaml');
+      var file = path.resolve(project.dirname, config.swagger.fileName);
       project.api.swagger = yaml.safeLoad(fs.readFileSync(file, 'utf8'));
     }
 


### PR DESCRIPTION
There is the ability to set the base swagger file in config settings (via config.js or environment variable) but it does not get picked up by project.js - it always looks for api/swagger/swagger.yaml
This fix changes it to use the config setting (which defaults to api/swagger/swagger.yaml if not overridden)
